### PR TITLE
Search parent directories for an elm-package.json

### DIFF
--- a/.sublimelinterrc
+++ b/.sublimelinterrc
@@ -5,7 +5,7 @@
             "max-line-length": 120
         },
         "pep257": {
-            "ignore": ["D202"]
+            "add-ignore": ["D202"]
         },
         "pep8": {
             "max-line-length": 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --add-ignore=D202

--- a/linter.py
+++ b/linter.py
@@ -47,6 +47,8 @@ class ElmMakeLint(Linter):
         root_dir = find_file_up('elm-package.json', os.path.abspath('.'))
         if root_dir:
             os.chdir(root_dir)
+        else:
+            return "error@@@1@@@@@@No elm-package.json found"
 
         cmd_output = super().run(cmd, code)
 

--- a/linter.py
+++ b/linter.py
@@ -23,7 +23,7 @@ class ElmMakeLint(Linter):
     """Provides an interface to elm-make linting."""
 
     syntax = 'elm'
-    cmd = 'elm-make --warn --report=json'
+    cmd = 'elm-make --warn --report=json --output=/dev/null'
     executable = None
     version_args = '--version'
     version_re = r'elm-make (?P<version>[\.\d]+)'

--- a/linter.py
+++ b/linter.py
@@ -19,7 +19,6 @@ from SublimeLinter.lint import Linter, util
 
 
 class ElmMakeLint(Linter):
-
     """Provides an interface to elm-make linting."""
 
     syntax = 'elm'
@@ -133,9 +132,8 @@ class ElmMakeLint(Linter):
 
 
 def find_file_up(filename, dirname):
-    """
-    Search for `filename` by recursively searching up through parent directories.
-    """
+    """Search for `filename` by recursively searching up through parent directories."""
+
     if os.path.exists(os.path.join(dirname, filename)):
         return dirname
     else:

--- a/linter.py
+++ b/linter.py
@@ -14,6 +14,7 @@
 
 import json
 import re
+import os
 from SublimeLinter.lint import Linter, util
 
 
@@ -42,6 +43,11 @@ class ElmMakeLint(Linter):
 
     def run(self, cmd, code):
         """Run elm-make, transform json into a string parseable by the regex."""
+
+        root_dir = find_file_up('elm-package.json', os.path.abspath('.'))
+        if root_dir:
+            os.chdir(root_dir)
+
         cmd_output = super().run(cmd, code)
 
         # Package errors are not output by json. :(
@@ -122,3 +128,16 @@ class ElmMakeLint(Linter):
                 type_mismatch.group('expected'), type_mismatch.group('actual'))
 
         return overview
+
+
+def find_file_up(filename, dirname):
+    """
+    Search for `filename` by recursively searching up through parent directories.
+    """
+    if os.path.exists(os.path.join(dirname, filename)):
+        return dirname
+    else:
+        nextdir = os.path.dirname(dirname)
+        if nextdir == dirname:
+            return None
+        return find_file_up(filename, nextdir)


### PR DESCRIPTION
This should fix #2

I set it to return an error if no elm-package.json is found, since elm-make currently creates an elm-package.json in the cwd... which is unfortunate. Assuming there's no valid reason to _not_ have one I think this is reasonable.
